### PR TITLE
check if assetQuantity is None. If so, don't caculate the security.

### DIFF
--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -457,10 +457,15 @@ class WealthsimpleAPI(WealthsimpleAPIBase):
             verb = act['subType'].replace('_', ' ').capitalize()
             action = 'buy' if act['type'] == 'DIY_BUY' else 'sell'
             security = self.security_id_to_symbol(act['securityId'])
-            act['description'] = (
-                f"{verb}: {action} {float(act['assetQuantity'])} x "
-                f"{security} @ {float(act['amount']) / float(act['assetQuantity'])}"
-            )
+            if act['assetQuantity'] is None:
+                act['description'] = (
+                    f"{verb}: {action} TBD"
+                )
+            else:
+                act['description'] = (
+                    f"{verb}: {action} {float(act['assetQuantity'])} x "
+                    f"{security} @ {float(act['amount']) / float(act['assetQuantity'])}"
+                )
 
         elif act['type'] in ['DEPOSIT', 'WITHDRAWAL'] and act['subType'] in ['E_TRANSFER', 'E_TRANSFER_FUNDING']:
             direction = 'from' if act['type'] == 'DEPOSIT' else 'to'


### PR DESCRIPTION
First of all, thank you for the amazing work!

Found a little kinda extreme case here.. when having an upcoming recurring buy transaction, the **assesQuantity** might be **None**.
```
Traceback (most recent call last):
  File "/chronos/scripts/ws-sync/ws-sync.py", line 329, in <module>
    WSApiTest().main()
  File "/chronos/scripts/ws-sync/ws-sync.py", line 241, in main
    acts = ws.get_activities(account['id'])
  File "/chronos/scripts/ws-sync/.venv/lib/python3.9/site-packages/ws_api/wealthsimple_api.py", line 435, in get_activities
    self._activity_add_description(act)
  File "/chronos/scripts/ws-sync/.venv/lib/python3.9/site-packages/ws_api/wealthsimple_api.py", line 461, in _activity_add_description
    f"{verb}: {action} {float(act['assetQuantity'])} x "
TypeError: float() argument must be a string or a number, not 'NoneType'
```
Example transaction:
```
{
  '__typename': 'ActivityFeedItem', 
  'accountId': 'xxxx-[redacted]', 
  'aftOriginatorName': None, 
  'aftTransactionCategory': None, 
  'aftTransactionType': None, 
  'amount': '300.0', 
  'amountSign': 'positive', 
  'assetQuantity': None, 
  'assetSymbol': 'PSA', 
  'billPayCompanyName': None, 
  'billPayPayeeNickname': None, 
  'canonicalId': 'recurring_investment_policy-[redacted]r', 
  'chequeNumber': None, 
  'contractType': None, 
  'counterAssetSymbol': None, 
  'counterPartyCurrency': None, 
  'counterPartyCurrencyAmount': None, 
  'counterPartyName': None, 
  'currency': 'CAD', 
  'description': 'DIY_BUY: RECURRING_ORDER_UPCOMING', 
  'eTransferEmail': None, 
  'eTransferName': None, 
  'expiryDate': None, 
  'externalCanonicalId': 'recurring_investment_policy-U[redacted]r', 
  'fees': None, 
  'frequency': 'BIWEEKLY', 
  'fxRate': None, 
  'identityId': None, 
  'institutionName': None, 
  'interestRate': None, 
  'occurredAt': '2025-08-11T11:00:00.000000+00:00', 
  'opposingAccountId': None, 
  'p2pHandle': None, 
  'p2pMessage': None, 
  'primaryBlocker': None, 
  'provisionalCreditAmount': None, 
  'redactedExternalAccountNumber': None, 
  'reference': None, 
  'rewardProgram': None, 
  'securityId': 'sec-s-71db[redacted]c2876', 
  'spendMerchant': None, 
  'status': None, 
  'strikePrice': None, 
  'subType': 'RECURRING_ORDER_UPCOMING', 
  'type': 'DIY_BUY'
}
```

Therefore, added a check before generating the description field..