### PR TITLE
new: description for "Non-registered: self-directed"

### DIFF
--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -342,6 +342,8 @@ class WealthsimpleAPI(WealthsimpleAPIBase):
             account['description'] = f"TFSA: self-directed - {account['currency']}"
         elif account['unifiedAccountType'] == 'MANAGED_TFSA':
             account['description'] = f"TFSA: managed - {account['currency']}"
+        elif account['unifiedAccountType'] == 'SELF_DIRECTED_NON_REGISTERED':
+            account['description'] = "Non-registered: self-directed"
         elif account['unifiedAccountType'] == 'SELF_DIRECTED_JOINT_NON_REGISTERED':
             account['description'] = "Non-registered: self-directed - joint"
         elif account['unifiedAccountType'] == 'SELF_DIRECTED_NON_REGISTERED_MARGIN':


### PR DESCRIPTION
Came across an unknown account type that probably should be handled.

---

On a side-note, I will be increasingly playing around with the API to integrate into one of my projects (https://github.com/Deigue/folio-updater) ...
While I can create pull-requests and suggestions around some fairly straightforward things such as handling of accounts and transaction types, do you have any preferences around how your ws-api handles API updates and just code convention in general?

For example, off top of my head:
- I was looking at `get_activities` in particular, since I was interested in historical activity and transactions, I notice that the graph QL query itself allows for an array, but the function signature passes an `accountId` . Would a preferred PR be updating the input as an array so the user has flexibility to provide multiple accounts, and setting the default to the same one accountId as it exists?
- I also notice loading into my formatter/linter, that naturally due to all the API being consolidated into one file, there is some repetition and cleanup that could be done (like repeated usage of response keys and such). I was wondering is it just a deliberate design decision to keep it all in one place, or more of keep it low maintainence and minimal. 
I wouldn't mind offering some PRs cleaning this up to some extent either, and willing to tweak through feedback reviewing the code. Figured I would ask beforehand, so I have a general idea if some cleanup or extra work is welcome. I can always fork off and make my own copy, but I think it is better to improve the source repo that is getting deployed to pypi
- Any advice on how you go about hunting down different GraphQL queries? I was able to find some in the console that dont already exist, but I dont think I would bother unless I actually need them. But for the existing GraphQL queries referenced, some arent immediately obvious how they are actually invoked in the real web-app. (not sure if that is useful as comments or description associated with the GraphQL query string in the code itself, to maintain in the future)