### PR TITLE
Allow pagination for get_activities

### DIFF
--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -412,7 +412,7 @@ class WealthsimpleAPI(WealthsimpleAPIBase):
             'array',
         )
 
-    def get_activities(self, account_id, how_many=50, order_by='OCCURRED_AT_DESC', ignore_rejected=True, start_date = None, end_date = None):
+    def get_activities(self, account_id, how_many=50, order_by='OCCURRED_AT_DESC', ignore_rejected=True, start_date = None, end_date = None, load_all = False):
         # Calculate the end date for the condition
         end_date = (end_date if end_date else datetime.now() + timedelta(hours=23, minutes=59, seconds=59, milliseconds=999))
 
@@ -436,6 +436,7 @@ class WealthsimpleAPI(WealthsimpleAPIBase):
             'activityFeedItems.edges',
             'array',
             filter_fn = filter_fn,
+            load_all_pages = load_all,
         )
 
         for act in activities:


### PR DESCRIPTION
Pagination is required to realistically get extended term of activities. This adds an optional parameter to allow loading multiple pages of results for activities.

---
- I experimented with `how_many` parameter, it likely is upper-bounded at 50. Increasing the value does not change anything. Probably is used to limit below 50 instead.
- This adds the pagination to `get_activities` as well. This seems to replicate the proper way to get extended term activities. Have verified this by setting a custom `start_date` where I know more than 50 activities should be returned and it works.