### PR TITLE
Subdivision: Fill currency type information

### DIFF
--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -564,6 +564,13 @@ class WealthsimpleAPI(WealthsimpleAPIBase):
                 received_shares: float = float(act['amount'])
                 act['description'] = f"Subdivision: Received {received_shares} new shares of {act['assetSymbol']}"
 
+            if act["currency"] is None:
+                security = self.get_security_market_data(act["securityId"])
+                if security and isinstance(security, dict):
+                    fundamentals = security.get("fundamentals")
+                    if fundamentals and isinstance(fundamentals, dict):
+                        act["currency"] = fundamentals.get("currency")
+
         elif act['type'] in ['DEPOSIT', 'WITHDRAWAL'] and act['subType'] in ['E_TRANSFER', 'E_TRANSFER_FUNDING']:
             direction = 'from' if act['type'] == 'DEPOSIT' else 'to'
             act['description'] = (


### PR DESCRIPTION
This lets the base activity inherit the currency type belonging to the security. (_only for Subdivision transactions_)

---

My project code/parser happens to suffix `.TO` to Canadian Tickers, and it seemed to be missing only on `CORPORATE_ACTION` / `SUBDIVISION` transactions.
On further inspection, the `currency` field was empty, so I couldn't make the inference on my side.

This adds it to the parent activity by retrieving the security details using the `securityId`