### PR TITLE
Handle no monthly txns gracefully

### DIFF
--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -805,7 +805,8 @@ class WealthsimpleAPI(WealthsimpleAPIBase):
             data = statement.get('data') if 'data' in statement else {}
             transactions = data.get('currentTransactions') if 'currentTransactions' in data else []
 
-
+        if not transactions:
+            return []
         if not isinstance(transactions, list):
             raise WSApiException(f"Unexpected response format: {self.get_statement_transactions.__name__}", transactions)
 


### PR DESCRIPTION
Requested monthly statement with args where the monthly statement isnt available yet. Naturally, the list of transactions will be empty or uninitialized. Noticed that this corner case wasnt handled, this provides a return value for when no transactions are available.