### PR TITLE
fix: handle GraphQL errors in security_id_to_symbol gracefully

### DIFF
--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -713,10 +713,14 @@ class WealthsimpleAPI(WealthsimpleAPIBase):
     def security_id_to_symbol(self, security_id: str) -> str:
         security_symbol = f"[{security_id}]"
         if self.security_market_data_cache_getter:
-            market_data = self.get_security_market_data(security_id)
-            if isinstance(market_data, dict) and market_data['stock']:
-                stock = market_data['stock']
-                security_symbol = f"{stock['primaryExchange']}:{stock['symbol']}"
+            try:
+                market_data = self.get_security_market_data(security_id)
+                if isinstance(market_data, dict) and market_data.get('stock'):
+                    stock = market_data['stock']
+                    security_symbol = f"{stock['primaryExchange']}:{stock['symbol']}"
+            except WSApiException:
+                # Some securities cannot be looked up (e.g., delisted or special securities)
+                pass
         return security_symbol
 
     def get_etf_details(self, funding_id):


### PR DESCRIPTION
## Problem

When using `get_account_balances`, `get_activities`, or other methods that internally call `security_id_to_symbol`, certain securities cause the API to fail (as they are delisted) with:

```
WSApiException: GraphQL query failed: FetchSecurityMarketData; 
Response: {'errors': [{'message': 'UNPROCESSABLE_ENTITY'}]}
```

This is noticeable with self-directed RRSP/TFSA accounts, certain ETFs, and some crypto positions.

## Solution

Wrap the `get_security_market_data` call in a try/except to catch `WSApiException` and gracefully fall back to the bracketed security ID.

## Changes

- Added try/except around `get_security_market_data` call (+4 lines)
- Changed `market_data['stock']` to `market_data.get('stock')` for safer access