### PR TITLE
Fix verb assignment for transaction descriptions

### DIFF
--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -556,9 +556,13 @@ class WealthsimpleAPI(WealthsimpleAPIBase):
             act['description'] = f"Money transfer: {direction} Wealthsimple {account_description}"
 
         elif act['type'] in ['DIY_BUY', 'DIY_SELL', 'MANAGED_BUY', 'MANAGED_SELL']:
-            verb = act['subType'].replace('_', ' ').capitalize()
+            # subType is None in some cases, so we can't rely on it up front.
+            # This could be the case for MANAGED actions, so we handle that separately.
+            verb = ''
             if 'MANAGED' in act['type']:
                 verb = "Managed transaction"
+            else:
+                verb = act['subType'].replace('_', ' ').capitalize()
             action = 'buy' if act['type'] == 'DIY_BUY' or act['type'] == 'MANAGED_BUY' else 'sell'
             security = self.security_id_to_symbol(act['securityId'])
             if act['assetQuantity'] is None:

--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -556,9 +556,6 @@ class WealthsimpleAPI(WealthsimpleAPIBase):
             act['description'] = f"Money transfer: {direction} Wealthsimple {account_description}"
 
         elif act['type'] in ['DIY_BUY', 'DIY_SELL', 'MANAGED_BUY', 'MANAGED_SELL']:
-            # subType is None in some cases, so we can't rely on it up front.
-            # This could be the case for MANAGED actions, so we handle that separately.
-            verb = ''
             if 'MANAGED' in act['type']:
                 verb = "Managed transaction"
             else:


### PR DESCRIPTION
What this does
---
- Handle None case for subType in transaction description.
- Example redacted transaction on which this failed:
```
{
    'accountId': 'non-registered-1235',
    'aftOriginatorName': 'None',
    'aftTransactionCategory': 'None',
    'aftTransactionType': 'None',
    'amount': '40.00',
    'amountSign': 'positive',
    'assetQuantity': '1.00',
    'assetSymbol': 'HBB',
    'canonicalId': 'DEC-25:ABCDE',
    'currency': 'CAD',
    'eTransferEmail': 'None',
    'eTransferName': 'None',
    'externalCanonicalId': 'order-12345',
    'identityId': 'None',
    'institutionName': 'None',
    'occurredAt': '2025-12-22T19:00:00.000000+00:00',
    'p2pHandle': 'None',
    'p2pMessage': 'None',
    'spendMerchant': 'None',
    'securityId': 'sec-s-12345',
    'billPayCompanyName': 'None',
    'billPayPayeeNickname': 'None',
    'redactedExternalAccountNumber': 'None',
    'opposingAccountId': 'None',
    'status': 'None',
    'subType': 'None',
    'type': 'MANAGED_BUY',
    'strikePrice': 'None',
    'contractType': 'None',
    'expiryDate': 'None',
    'chequeNumber': 'None',
    'provisionalCreditAmount': 'None',
    'primaryBlocker': 'None',
    'interestRate': 'None',
    'frequency': 'None',
    'counterAssetSymbol': 'None',
    'rewardProgram': 'None',
    'counterPartyCurrency': 'None',
    'counterPartyCurrencyAmount': 'None',
    'counterPartyName': 'None',
    'fxRate': 'None',
    'fees': 'None',
    'reference': 'None',
    '__typename': 'ActivityFeedItem',
    'description': 'MANAGED_BUY: None'
}

```