### PR TITLE
Fix regex matches to work with new login page

### DIFF
--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -122,7 +122,7 @@ class WealthsimpleAPIBase:
             for line in response.splitlines():
                 # Look for wssdi in set-cookie headers
                 if not self.session.wssdi and "set-cookie:" in line.lower():
-                    match = re.search(r"wssdi=([a-f0-9]+);", line, re.IGNORECASE)
+                    match = re.search(r"wssdi=([a-f0-9-]+);", line, re.IGNORECASE)
                     if match:
                         self.session.wssdi = match.group(1)
 
@@ -149,7 +149,7 @@ class WealthsimpleAPIBase:
 
             # Look for clientId in the app JS file
             match = re.search(
-                r'production:.*clientId:"([a-f0-9]+)"', response, re.IGNORECASE
+                r'production.*clientId:"([a-f0-9]+)"', response, re.IGNORECASE
             )
             if match:
                 self.session.client_id = match.group(1)


### PR DESCRIPTION
I noticed that the start_session function was failing a few days ago.  Took some time to investigate and it seems like a few things on the login page have changed.

This PR updates the regex matches so that the new login page is recognized. 