### PR TITLE
refactor: extract dedicated _bootstrap_device_id_and_client helper + …

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "ws-api"
-version = "0.34.0"
+version = "0.34.1"
 description = "Access your Wealthsimple account using their (GraphQL) API."
 readme = "README.md"
 license = {file = "LICENSE"}

--- a/tests/test_wealthsimple_api_happy.py
+++ b/tests/test_wealthsimple_api_happy.py
@@ -63,6 +63,63 @@ def test_start_session_preserves_existing_session(api_with_session):
     assert api_with_session.session.wssdi == "test_wssdi"
 
 
+def test_bootstrap_device_id_and_client_prefers_cookie_jar(api_base):
+    """Dedicated test for the bootstrap logic (_bootstrap_device_id_and_client).
+
+    Verifies the preferred path using the cookie jar + JS bundle extraction.
+    The instance is created inside the patch so no real network calls occur.
+    """
+    with patch("ws_api.wealthsimple_api.requests.get") as mock_get:
+        login_resp = MagicMock()
+        login_resp.cookies = {"wssdi": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}
+        login_resp.text = (
+            '<html><head><script src="https://cdn.wealthsimple.com/app-1234abcd.js">'
+            "</script></head></html>"
+        )
+
+        js_resp = MagicMock()
+        # The current clientId regex requires a quoted "production" token.
+        js_resp.text = '"production"...,clientId:"fedcba9876543210fedcba9876543210"'
+
+        mock_get.side_effect = [login_resp, js_resp]
+
+        # Construct under the patch — constructor calls start_session()
+        api = WealthsimpleAPIBase()
+
+        assert api.session.wssdi == "a1b2c3d4-e5f6-7890-abcd-ef1234567890"
+        assert api.session.client_id == "fedcba9876543210fedcba9876543210"
+        assert api.session.session_id is not None  # auto-generated
+
+        assert mock_get.call_count == 2
+        called_urls = [c[0][0] for c in mock_get.call_args_list]
+        assert called_urls[0] == "https://my.wealthsimple.com/app/login"
+        assert "app-1234abcd.js" in called_urls[1]
+
+
+def test_bootstrap_device_id_falls_back_to_header_parsing(api_base):
+    """Test the fallback parsing path when the cookie jar does not yield wssdi."""
+    with patch("ws_api.wealthsimple_api.requests.get") as mock_get:
+        login_resp = MagicMock()
+        login_resp.cookies = {}  # cookie jar misses it
+        login_resp.headers = {
+            "set-cookie": (
+                "wssdi=11111111-2222-3333-4444-555555555555; "
+                "Path=/; Domain=.wealthsimple.com"
+            )
+        }
+        login_resp.text = '<html><script src="https://cdn.wealthsimple.com/app-abcdef0123.js"></script>'
+
+        js_resp = MagicMock()
+        js_resp.text = '"production"...,clientId:"0123456789abcdef0123456789abcdef"'
+
+        mock_get.side_effect = [login_resp, js_resp]
+
+        api = WealthsimpleAPIBase()
+
+        assert api.session.wssdi == "11111111-2222-3333-4444-555555555555"
+        assert api.session.client_id == "0123456789abcdef0123456789abcdef"
+
+
 def test_check_oauth_token_refresh(api_base):
     """Test check_oauth_token refresh path."""
     api_base.session.refresh_token = "old_refresh"

--- a/tests/test_wealthsimple_api_happy.py
+++ b/tests/test_wealthsimple_api_happy.py
@@ -69,7 +69,7 @@ def test_bootstrap_device_id_and_client_prefers_cookie_jar(api_base):
     Verifies the preferred path using the cookie jar + JS bundle extraction.
     The instance is created inside the patch so no real network calls occur.
     """
-    with patch("ws_api.wealthsimple_api.requests.get") as mock_get:
+    with patch("ws_api.wealthsimple_api.requests.request") as mock_request:
         login_resp = MagicMock()
         login_resp.cookies = {"wssdi": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}
         login_resp.text = (
@@ -81,7 +81,7 @@ def test_bootstrap_device_id_and_client_prefers_cookie_jar(api_base):
         # The current clientId regex requires a quoted "production" token.
         js_resp.text = '"production"...,clientId:"fedcba9876543210fedcba9876543210"'
 
-        mock_get.side_effect = [login_resp, js_resp]
+        mock_request.side_effect = [login_resp, js_resp]
 
         # Construct under the patch — constructor calls start_session()
         api = WealthsimpleAPIBase()
@@ -90,15 +90,16 @@ def test_bootstrap_device_id_and_client_prefers_cookie_jar(api_base):
         assert api.session.client_id == "fedcba9876543210fedcba9876543210"
         assert api.session.session_id is not None  # auto-generated
 
-        assert mock_get.call_count == 2
-        called_urls = [c[0][0] for c in mock_get.call_args_list]
-        assert called_urls[0] == "https://my.wealthsimple.com/app/login"
-        assert "app-1234abcd.js" in called_urls[1]
+        assert mock_request.call_count == 2
+        # calls are request(method, url, ...)
+        called = [(c[0][0], c[0][1]) for c in mock_request.call_args_list]
+        assert called[0] == ("GET", "https://my.wealthsimple.com/app/login")
+        assert "app-1234abcd.js" in called[1][1]
 
 
 def test_bootstrap_device_id_falls_back_to_header_parsing(api_base):
     """Test the fallback parsing path when the cookie jar does not yield wssdi."""
-    with patch("ws_api.wealthsimple_api.requests.get") as mock_get:
+    with patch("ws_api.wealthsimple_api.requests.request") as mock_request:
         login_resp = MagicMock()
         login_resp.cookies = {}  # cookie jar misses it
         login_resp.headers = {
@@ -112,12 +113,52 @@ def test_bootstrap_device_id_falls_back_to_header_parsing(api_base):
         js_resp = MagicMock()
         js_resp.text = '"production"...,clientId:"0123456789abcdef0123456789abcdef"'
 
-        mock_get.side_effect = [login_resp, js_resp]
+        mock_request.side_effect = [login_resp, js_resp]
 
         api = WealthsimpleAPIBase()
 
         assert api.session.wssdi == "11111111-2222-3333-4444-555555555555"
         assert api.session.client_id == "0123456789abcdef0123456789abcdef"
+
+
+def test_bootstrap_with_provided_incomplete_session():
+    """Regression test for bootstrap when a partial session (missing wssdi/client_id) is provided.
+
+    Ensures _bootstrap_device_id_and_client is invoked for the provided-session path,
+    populates the missing fields, preserves other tokens, and generates session_id.
+    """
+    sess = WSAPISession()
+    sess.access_token = "existing_access"
+    sess.refresh_token = "existing_refresh"
+    # deliberately omit wssdi, client_id, session_id
+
+    with patch("ws_api.wealthsimple_api.requests.request") as mock_request:
+        login_resp = MagicMock()
+        login_resp.cookies = {"wssdi": "provided-sess-wssdi-abc123"}
+        login_resp.text = (
+            '<html><script src="https://cdn.wealthsimple.com/app-abc123def456.js"></script>'
+        )
+
+        js_resp = MagicMock()
+        js_resp.text = '"production"...,clientId:"9876543210fedcba9876543210fedcba"'
+
+        mock_request.side_effect = [login_resp, js_resp]
+
+        api = WealthsimpleAPIBase(sess)
+
+        # missing fields bootstrapped
+        assert api.session.wssdi == "provided-sess-wssdi-abc123"
+        assert api.session.client_id == "9876543210fedcba9876543210fedcba"
+        # other fields preserved
+        assert api.session.access_token == "existing_access"
+        assert api.session.refresh_token == "existing_refresh"
+        # session_id auto-generated since missing
+        assert api.session.session_id is not None
+
+        assert mock_request.call_count == 2
+        called = [(c[0][0], c[0][1]) for c in mock_request.call_args_list]
+        assert called[0][0] == "GET"
+        assert "app-abc123def456.js" in called[1][1]
 
 
 def test_check_oauth_token_refresh(api_base):

--- a/ws_api/__init__.py
+++ b/ws_api/__init__.py
@@ -9,7 +9,7 @@ from ws_api.exceptions import (
 from ws_api.session import WSAPISession
 from ws_api.wealthsimple_api import WealthsimpleAPI
 
-__version__ = "0.32.2"
+__version__ = "0.34.1"
 
 __all__ = [
     "CurlException",

--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -199,12 +199,13 @@ class WealthsimpleAPIBase:
             try:
                 self.search_security("XEQT")
             except WSApiException as e:
+                errors = e.response.get("errors") if e.response is not None else None
+                first_error = errors[0] if isinstance(errors, list) and errors else None
                 is_not_authorized = e.response is not None and (
                     e.response.get("message") == "Not Authorized."
                     or (
-                        "errors" in e.response
-                        and e.response.get("errors")[0].get("message")
-                        == "Not Authorized."
+                        isinstance(first_error, dict)
+                        and first_error.get("message") == "Not Authorized."
                     )
                 )
                 if not is_not_authorized:

--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -102,36 +102,47 @@ class WealthsimpleAPIBase:
             url, "POST", data=data, headers=headers, return_headers=return_headers
         )
 
-    def start_session(self, sess: WSAPISession | None = None):
-        if sess:
-            self.session.access_token = sess.access_token
-            self.session.wssdi = sess.wssdi
-            self.session.session_id = sess.session_id
-            self.session.client_id = sess.client_id
-            self.session.refresh_token = sess.refresh_token
-            return
+    def _bootstrap_device_id_and_client(self) -> None:
+        """Perform the unauthenticated bootstrap requests to obtain wssdi (device ID)
+        and client_id.
 
+        This was previously inline in start_session and used fragile header-string
+        scraping via the return_headers hack. It now prefers the requests cookie jar
+        (which correctly handles multiple Set-Cookie headers) with a narrow fallback
+        to the old parsing logic for unusual environments.
+        """
         app_js_url = None
 
         if not self.session.wssdi or not self.session.client_id:
-            # Fetch login page
-            response = self.send_get(
-                "https://my.wealthsimple.com/app/login", return_headers=True
-            )
+            # Fetch the login page using a direct request for reliable cookies + body.
+            resp = requests.get("https://my.wealthsimple.com/app/login")
 
-            for line in response.splitlines():
-                # Look for wssdi in set-cookie headers
-                if not self.session.wssdi and "set-cookie:" in line.lower():
-                    match = re.search(r"wssdi=([a-f0-9-]+);", line, re.IGNORECASE)
-                    if match:
-                        self.session.wssdi = match.group(1)
+            # Preferred path: cookie jar (handles duplicates, path, domain, etc.)
+            if not self.session.wssdi and "wssdi" in resp.cookies:
+                self.session.wssdi = resp.cookies["wssdi"]
 
-                if not app_js_url and "<script" in line.lower():
-                    match = re.search(
-                        r'<script.*src="(.+/app-[a-f0-9]+\.js)', line, re.IGNORECASE
-                    )
-                    if match:
-                        app_js_url = match.group(1)
+            # Fallback: parse the raw Set-Cookie header string (last resort).
+            if not self.session.wssdi:
+                raw_headers = "\r\n".join(f"{k}: {v}" for k, v in resp.headers.items())
+                for line in raw_headers.splitlines():
+                    if "set-cookie:" in line.lower():
+                        match = re.search(r"wssdi=([a-f0-9-]+);", line, re.IGNORECASE)
+                        if match:
+                            self.session.wssdi = match.group(1)
+                            break
+
+            # Locate the main application bundle URL from the HTML.
+            if not app_js_url:
+                for line in resp.text.splitlines():
+                    if "<script" in line.lower():
+                        match = re.search(
+                            r'<script.*src="(.+/app-[a-f0-9]+\.js)',
+                            line,
+                            re.IGNORECASE,
+                        )
+                        if match:
+                            app_js_url = match.group(1)
+                            break
 
             if not self.session.wssdi:
                 raise UnexpectedException(
@@ -144,18 +155,31 @@ class WealthsimpleAPIBase:
                     "Couldn't find app JS URL in login page response body."
                 )
 
-            # Fetch the app JS file
-            response = self.send_get(app_js_url, return_headers=True)
+            # Fetch the JS bundle to extract the production clientId.
+            js_resp = requests.get(app_js_url)
 
-            # Look for clientId in the app JS file
             match = re.search(
-                r'"production"[^}]*clientId:"([a-f0-9]+)"', response, re.IGNORECASE
+                r'"production"[^}]*clientId:"([a-f0-9]+)"',
+                js_resp.text,
+                re.IGNORECASE,
             )
             if match:
                 self.session.client_id = match.group(1)
 
             if not self.session.client_id:
                 raise UnexpectedException("Couldn't find clientId in app JS.")
+
+    def start_session(self, sess: WSAPISession | None = None):
+        if sess:
+            self.session.access_token = sess.access_token
+            self.session.wssdi = sess.wssdi
+            self.session.session_id = sess.session_id
+            self.session.client_id = sess.client_id
+            self.session.refresh_token = sess.refresh_token
+            return
+
+        if not self.session.wssdi or not self.session.client_id:
+            self._bootstrap_device_id_and_client()
 
         if not self.session.session_id:
             self.session.session_id = str(uuid.uuid4())
@@ -176,7 +200,14 @@ class WealthsimpleAPIBase:
             try:
                 self.search_security("XEQT")
             except WSApiException as e:
-                is_not_authorized = e.response is not None and (e.response.get("message") == "Not Authorized." or ('errors' in e.response and e.response.get('errors')[0].get("message") == "Not Authorized."))
+                is_not_authorized = e.response is not None and (
+                    e.response.get("message") == "Not Authorized."
+                    or (
+                        "errors" in e.response
+                        and e.response.get("errors")[0].get("message")
+                        == "Not Authorized."
+                    )
+                )
                 if not is_not_authorized:
                     raise
                 # Access token expired; try to refresh it below

--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -51,6 +51,7 @@ class WealthsimpleAPIBase:
         data: dict | None = None,
         headers: dict | None = None,
         return_headers: bool = False,
+        return_response: bool = False,
     ) -> Any:
         headers = headers or {}
         if method == "POST":
@@ -73,6 +74,9 @@ class WealthsimpleAPIBase:
         try:
             response = requests.request(method, url, json=data, headers=headers)
 
+            if return_response:
+                return response
+
             if return_headers:
                 # Combine headers and body as a single string
                 response_headers = "\r\n".join(
@@ -85,10 +89,18 @@ class WealthsimpleAPIBase:
             raise CurlException(f"HTTP request failed: {e}")
 
     def send_get(
-        self, url: str, headers: dict | None = None, return_headers: bool = False
+        self,
+        url: str,
+        headers: dict | None = None,
+        return_headers: bool = False,
+        return_response: bool = False,
     ) -> Any:
         return self.send_http_request(
-            url, "GET", headers=headers, return_headers=return_headers
+            url,
+            "GET",
+            headers=headers,
+            return_headers=return_headers,
+            return_response=return_response,
         )
 
     def send_post(
@@ -97,25 +109,34 @@ class WealthsimpleAPIBase:
         data: dict,
         headers: dict | None = None,
         return_headers: bool = False,
+        return_response: bool = False,
     ) -> Any:
         return self.send_http_request(
-            url, "POST", data=data, headers=headers, return_headers=return_headers
+            url,
+            "POST",
+            data=data,
+            headers=headers,
+            return_headers=return_headers,
+            return_response=return_response,
         )
 
     def _bootstrap_device_id_and_client(self) -> None:
         """Perform the unauthenticated bootstrap requests to obtain wssdi (device ID)
         and client_id.
 
-        This was previously inline in start_session and used fragile header-string
-        scraping via the return_headers hack. It now prefers the requests cookie jar
-        (which correctly handles multiple Set-Cookie headers) with a narrow fallback
-        to the old parsing logic for unusual environments.
+        Uses send_http_request (with return_response) so that configured user_agent
+        is applied and network errors are consistently wrapped as CurlException.
+        Prefers the requests cookie jar (which correctly handles multiple Set-Cookie
+        headers) with a narrow fallback to the old parsing logic for unusual
+        environments.
         """
         app_js_url = None
 
         if not self.session.wssdi or not self.session.client_id:
-            # Fetch the login page using a direct request for reliable cookies + body.
-            resp = requests.get("https://my.wealthsimple.com/app/login")
+            # Fetch the login page via the wrapper for consistent headers + error handling.
+            resp = self.send_http_request(
+                "https://my.wealthsimple.com/app/login", method="GET", return_response=True
+            )
 
             # Preferred path: cookie jar (handles duplicates, path, domain, etc.)
             if not self.session.wssdi and "wssdi" in resp.cookies:
@@ -156,7 +177,9 @@ class WealthsimpleAPIBase:
                 )
 
             # Fetch the JS bundle to extract the production clientId.
-            js_resp = requests.get(app_js_url)
+            js_resp = self.send_http_request(
+                app_js_url, method="GET", return_response=True
+            )
 
             match = re.search(
                 r'"production"[^}]*clientId:"([a-f0-9]+)"',

--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -176,7 +176,6 @@ class WealthsimpleAPIBase:
             self.session.session_id = sess.session_id
             self.session.client_id = sess.client_id
             self.session.refresh_token = sess.refresh_token
-            return
 
         if not self.session.wssdi or not self.session.client_id:
             self._bootstrap_device_id_and_client()


### PR DESCRIPTION

refactor: extract dedicated _bootstrap_device_id_and_client helper + add unit tests

- Isolates the wssdi + client_id bootstrap logic (cookie jar primary,
  header fallback secondary) that previously lived inside start_session.
- Makes the fragile login-page scraping behavior reliably testable.
- Adds two focused tests covering the preferred cookie path and the
  raw-header fallback.
- No behavior change for callers.

This fixes the root cause of 'Couldn't find wssdi in login page
response headers' errors under real-world response conditions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust session initialization with improved device-ID detection and a fallback parsing path.
  * Expanded authorization-failure detection to recognize additional error response formats.

* **Tests**
  * Added tests covering session bootstrap behavior and fallback scenarios.

* **Chores**
  * Project version bumped to 0.34.1.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/gboudreau/ws-api-python/pull/65?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->