### PR TITLE
Switch to curl_cffi to bypass automation protections

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
 requires-python = ">=3.10"
 dependencies = [
   "requests",
+  "curl_cffi",
 ]
 keywords = ["wealthsimple"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,6 @@ classifiers = [
 ]
 requires-python = ">=3.10"
 dependencies = [
-  "requests",
   "curl_cffi",
 ]
 keywords = ["wealthsimple"]

--- a/tests/test_wealthsimple_api.py
+++ b/tests/test_wealthsimple_api.py
@@ -57,8 +57,8 @@ def test_send_http_request_post(mock_request, mock_session):
 
     mock_request.assert_called_once()
     args, kwargs = mock_request.call_args
-    assert args[0] == "POST"
-    assert args[1] == "https://test.example.com/api"
+    assert kwargs["method"] == "POST"
+    assert kwargs["url"] == "https://test.example.com/api"
     assert kwargs["json"] == {
         "grant_type": "password",
         "username": "test",
@@ -85,8 +85,8 @@ def test_send_get_request(mock_request, mock_session):
 
     mock_request.assert_called_once()
     args, kwargs = mock_request.call_args
-    assert args[0] == "GET"
-    assert args[1] == "https://test.example.com/get"
+    assert kwargs["method"] == "GET"
+    assert kwargs["url"] == "https://test.example.com/get"
     headers = kwargs["headers"]
     assert "x-ws-session-id" in headers
     assert headers["x-ws-session-id"] == "test_session_id"

--- a/tests/test_wealthsimple_api.py
+++ b/tests/test_wealthsimple_api.py
@@ -39,7 +39,7 @@ def test_wealthsimple_api_init_with_session(mock_session):
     assert api.session.wssdi == "test_wssdi"
 
 
-@patch("requests.request")
+@patch("curl_cffi.requests.Session.request")
 def test_send_http_request_post(mock_request, mock_session):
     mock_resp = MagicMock()
     mock_resp.json.return_value = {"status": "ok"}
@@ -71,7 +71,7 @@ def test_send_http_request_post(mock_request, mock_session):
     assert headers["x-ws-device-id"] == "test_wssdi"
 
 
-@patch("requests.request")
+@patch("curl_cffi.requests.Session.request")
 def test_send_get_request(mock_request, mock_session):
     mock_resp = MagicMock()
     mock_resp.json.return_value = {"status": "ok"}

--- a/tests/test_wealthsimple_api_happy.py
+++ b/tests/test_wealthsimple_api_happy.py
@@ -29,7 +29,7 @@ def api():
 
 def test_send_http_request_return_headers(api_base):
     """Test send_http_request with return_headers=True path."""
-    with patch("ws_api.wealthsimple_api.requests.request") as mock_request:
+    with patch("curl_cffi.requests.Session.request") as mock_request:
         mock_resp = MagicMock()
         mock_resp.headers = {"Set-Cookie": "wssdi=test; path=/"}
         mock_resp.text = "response body"
@@ -45,7 +45,7 @@ def test_send_http_request_return_headers(api_base):
 
 def test_send_post(api_base):
     """Test send_post delegation."""
-    with patch("ws_api.wealthsimple_api.requests.request") as mock_request:
+    with patch("curl_cffi.requests.Session.request") as mock_request:
         mock_resp = MagicMock()
         mock_resp.json.return_value = {"ok": True}
         mock_request.return_value = mock_resp
@@ -69,7 +69,7 @@ def test_bootstrap_device_id_and_client_prefers_cookie_jar(api_base):
     Verifies the preferred path using the cookie jar + JS bundle extraction.
     The instance is created inside the patch so no real network calls occur.
     """
-    with patch("ws_api.wealthsimple_api.requests.request") as mock_request:
+    with patch("curl_cffi.requests.Session.get") as mock_request:
         login_resp = MagicMock()
         login_resp.cookies = {"wssdi": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}
         login_resp.text = (
@@ -99,7 +99,7 @@ def test_bootstrap_device_id_and_client_prefers_cookie_jar(api_base):
 
 def test_bootstrap_device_id_falls_back_to_header_parsing(api_base):
     """Test the fallback parsing path when the cookie jar does not yield wssdi."""
-    with patch("ws_api.wealthsimple_api.requests.request") as mock_request:
+    with patch("curl_cffi.requests.Session.get") as mock_request:
         login_resp = MagicMock()
         login_resp.cookies = {}  # cookie jar misses it
         login_resp.headers = {
@@ -132,7 +132,7 @@ def test_bootstrap_with_provided_incomplete_session():
     sess.refresh_token = "existing_refresh"
     # deliberately omit wssdi, client_id, session_id
 
-    with patch("ws_api.wealthsimple_api.requests.request") as mock_request:
+    with patch("curl_cffi.requests.Session.get") as mock_request:
         login_resp = MagicMock()
         login_resp.cookies = {"wssdi": "provided-sess-wssdi-abc123"}
         login_resp.text = (

--- a/tests/test_wealthsimple_api_happy.py
+++ b/tests/test_wealthsimple_api_happy.py
@@ -10,7 +10,10 @@ from ws_api.wealthsimple_api import WealthsimpleAPI, WealthsimpleAPIBase
 
 @pytest.fixture
 def api_base():
-    return WealthsimpleAPIBase()
+    sess = WSAPISession()
+    sess.client_id = "test_client_id"
+    sess.wssdi = "test_wssdi"
+    return WealthsimpleAPIBase(sess)
 
 
 @pytest.fixture
@@ -24,7 +27,10 @@ def api_with_session():
 
 @pytest.fixture
 def api():
-    return WealthsimpleAPI()
+    sess = WSAPISession()
+    sess.client_id = "test_client_id"
+    sess.wssdi = "test_wssdi"
+    return WealthsimpleAPI(sess)
 
 
 def test_send_http_request_return_headers(api_base):
@@ -69,7 +75,10 @@ def test_bootstrap_device_id_and_client_prefers_cookie_jar(api_base):
     Verifies the preferred path using the cookie jar + JS bundle extraction.
     The instance is created inside the patch so no real network calls occur.
     """
-    with patch("curl_cffi.requests.Session.get") as mock_request:
+    with patch("curl_cffi.requests.Session") as MockSession:
+        mock_session_instance = MagicMock()
+        MockSession.return_value = mock_session_instance
+         
         login_resp = MagicMock()
         login_resp.cookies = {"wssdi": "a1b2c3d4-e5f6-7890-abcd-ef1234567890"}
         login_resp.text = (
@@ -81,7 +90,7 @@ def test_bootstrap_device_id_and_client_prefers_cookie_jar(api_base):
         # The current clientId regex requires a quoted "production" token.
         js_resp.text = '"production"...,clientId:"fedcba9876543210fedcba9876543210"'
 
-        mock_request.side_effect = [login_resp, js_resp]
+        mock_session_instance.request.side_effect = [login_resp, js_resp]
 
         # Construct under the patch — constructor calls start_session()
         api = WealthsimpleAPIBase()
@@ -90,16 +99,19 @@ def test_bootstrap_device_id_and_client_prefers_cookie_jar(api_base):
         assert api.session.client_id == "fedcba9876543210fedcba9876543210"
         assert api.session.session_id is not None  # auto-generated
 
-        assert mock_request.call_count == 2
-        # calls are request(method, url, ...)
-        called = [(c[0][0], c[0][1]) for c in mock_request.call_args_list]
+        assert mock_session_instance.request.call_count == 2
+        # calls are request(method=..., url=...)
+        called = [(c.kwargs['method'], c.kwargs['url']) for c in mock_session_instance.request.call_args_list]
         assert called[0] == ("GET", "https://my.wealthsimple.com/app/login")
         assert "app-1234abcd.js" in called[1][1]
 
 
 def test_bootstrap_device_id_falls_back_to_header_parsing(api_base):
     """Test the fallback parsing path when the cookie jar does not yield wssdi."""
-    with patch("curl_cffi.requests.Session.get") as mock_request:
+    with patch("curl_cffi.requests.Session") as MockSession:
+        mock_session_instance = MagicMock()
+        MockSession.return_value = mock_session_instance
+         
         login_resp = MagicMock()
         login_resp.cookies = {}  # cookie jar misses it
         login_resp.headers = {
@@ -113,7 +125,7 @@ def test_bootstrap_device_id_falls_back_to_header_parsing(api_base):
         js_resp = MagicMock()
         js_resp.text = '"production"...,clientId:"0123456789abcdef0123456789abcdef"'
 
-        mock_request.side_effect = [login_resp, js_resp]
+        mock_session_instance.request.side_effect = [login_resp, js_resp]
 
         api = WealthsimpleAPIBase()
 
@@ -132,7 +144,10 @@ def test_bootstrap_with_provided_incomplete_session():
     sess.refresh_token = "existing_refresh"
     # deliberately omit wssdi, client_id, session_id
 
-    with patch("curl_cffi.requests.Session.get") as mock_request:
+    with patch("curl_cffi.requests.Session") as MockSession:
+        mock_session_instance = MagicMock()
+        MockSession.return_value = mock_session_instance
+         
         login_resp = MagicMock()
         login_resp.cookies = {"wssdi": "provided-sess-wssdi-abc123"}
         login_resp.text = (
@@ -142,7 +157,7 @@ def test_bootstrap_with_provided_incomplete_session():
         js_resp = MagicMock()
         js_resp.text = '"production"...,clientId:"9876543210fedcba9876543210fedcba"'
 
-        mock_request.side_effect = [login_resp, js_resp]
+        mock_session_instance.request.side_effect = [login_resp, js_resp]
 
         api = WealthsimpleAPIBase(sess)
 
@@ -155,8 +170,8 @@ def test_bootstrap_with_provided_incomplete_session():
         # session_id auto-generated since missing
         assert api.session.session_id is not None
 
-        assert mock_request.call_count == 2
-        called = [(c[0][0], c[0][1]) for c in mock_request.call_args_list]
+        assert mock_session_instance.request.call_count == 2
+        called = [(c.kwargs['method'], c.kwargs['url']) for c in mock_session_instance.request.call_args_list]
         assert called[0][0] == "GET"
         assert "app-abc123def456.js" in called[1][1]
 

--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -46,6 +46,82 @@ class WealthsimpleAPIBase:
     def uuidv4() -> str:
         return str(uuid.uuid4())
 
+    def send_http_request(
+        self,
+        url: str,
+        method: str = "POST",
+        data: dict | None = None,
+        headers: dict | None = None,
+        return_headers: bool = False,
+        return_response: bool = False,
+    ) -> Any:
+        headers = headers or {}
+        if method == "POST":
+            headers["Content-Type"] = "application/json"
+
+        if self.session.session_id:
+            headers["x-ws-session-id"] = self.session.session_id
+
+        if self.session.access_token and (
+            not data or data.get("grant_type") != "refresh_token"
+        ):
+            headers["Authorization"] = f"Bearer {self.session.access_token}"
+
+        if self.session.wssdi:
+            headers["x-ws-device-id"] = self.session.wssdi
+
+        if WealthsimpleAPI.user_agent:
+            headers["User-Agent"] = WealthsimpleAPI.user_agent
+
+        try:
+            response = self.http.request(method, url, json=data, headers=headers)
+
+            if return_response:
+                return response
+
+            if return_headers:
+                # Combine headers and body as a single string
+                response_headers = "\r\n".join(
+                    f"{k}: {v}" for k, v in response.headers.items()
+                )
+                return f"{response_headers}\r\n\r\n{response.text}"
+
+            return response.json()
+        except RequestException as e:
+            raise CurlException(f"HTTP request failed: {e}")
+
+    def send_get(
+        self,
+        url: str,
+        headers: dict | None = None,
+        return_headers: bool = False,
+        return_response: bool = False,
+    ) -> Any:
+        return self.send_http_request(
+            url,
+            "GET",
+            headers=headers,
+            return_headers=return_headers,
+            return_response=return_response,
+        )
+
+    def send_post(
+        self,
+        url: str,
+        data: dict,
+        headers: dict | None = None,
+        return_headers: bool = False,
+        return_response: bool = False,
+    ) -> Any:
+        return self.send_http_request(
+            url,
+            "POST",
+            data=data,
+            headers=headers,
+            return_headers=return_headers,
+            return_response=return_response,
+        )
+
     def _bootstrap_device_id_and_client(self) -> None:
         """Perform the unauthenticated bootstrap requests to obtain wssdi (device ID)
         and client_id.
@@ -311,7 +387,7 @@ class WealthsimpleAPIBase:
             headers["x-ws-session-id"] = self.session.session_id
 
         if self.session.access_token:
-            headers["Authorization"] = f"Bearer {self.session.access_token}"
+            headers["Authorization"] = f"******"
 
         if self.session.wssdi:
             headers["x-ws-device-id"] = self.session.wssdi
@@ -390,7 +466,7 @@ class WealthsimpleAPIBase:
                 headers["x-ws-session-id"] = self.session.session_id
 
             if self.session.access_token:
-                headers["Authorization"] = f"Bearer {self.session.access_token}"
+                headers["Authorization"] = f"******"
 
             if self.session.wssdi:
                 headers["x-ws-device-id"] = self.session.wssdi

--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -138,8 +138,8 @@ class WealthsimpleAPIBase:
                 if WealthsimpleAPI.user_agent:
                     headers["User-Agent"] = WealthsimpleAPI.user_agent
 
-                resp = self.http.get(
-                    "https://my.wealthsimple.com/app/login", headers=headers
+                resp = self.send_get(
+                    "https://my.wealthsimple.com/app/login", headers=headers, return_response=True
                 )
             except RequestException as e:
                 raise CurlException(f"HTTP request failed: {e}")
@@ -187,7 +187,7 @@ class WealthsimpleAPIBase:
                 if WealthsimpleAPI.user_agent:
                     headers["User-Agent"] = WealthsimpleAPI.user_agent
 
-                js_resp = self.http.get(app_js_url, headers=headers)
+                js_resp = self.send_get(app_js_url, headers=headers, return_response=True)
             except RequestException as e:
                 raise CurlException(f"HTTP request failed: {e}")
 
@@ -266,9 +266,9 @@ class WealthsimpleAPIBase:
                 headers["User-Agent"] = WealthsimpleAPI.user_agent
 
             try:
-                response = self.http.post(
-                    f"{self.OAUTH_BASE_URL}/token", json=data, headers=headers
-                ).json()
+                response = self.send_post(
+                    f"{self.OAUTH_BASE_URL}/token", data=data, headers=headers
+                )
             except RequestException as e:
                 raise CurlException(f"HTTP request failed: {e}")
 
@@ -330,9 +330,9 @@ class WealthsimpleAPIBase:
 
         # Send the POST request for token
         try:
-            response_data = self.http.post(
-                f"{self.OAUTH_BASE_URL}/token", json=data, headers=headers
-            ).json()
+            response_data = self.send_post(
+                f"{self.OAUTH_BASE_URL}/token", data=data, headers=headers
+            )
         except RequestException as e:
             raise CurlException(f"HTTP request failed: {e}")
 
@@ -396,9 +396,9 @@ class WealthsimpleAPIBase:
             headers["User-Agent"] = WealthsimpleAPI.user_agent
 
         try:
-            response_data = self.http.post(
-                self.GRAPHQL_URL, json=query, headers=headers
-            ).json()
+            response_data = self.send_post(
+                self.GRAPHQL_URL, data=query, headers=headers
+            )
         except RequestException as e:
             raise CurlException(f"HTTP request failed: {e}")
 
@@ -475,9 +475,9 @@ class WealthsimpleAPIBase:
                 headers["User-Agent"] = WealthsimpleAPI.user_agent
 
             try:
-                response = self.http.get(
+                response = self.send_get(
                     self.OAUTH_BASE_URL + "/token/info", headers=headers
-                ).json()
+                )
             except RequestException as e:
                 raise CurlException(f"HTTP request failed: {e}")
 

--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -74,7 +74,11 @@ class WealthsimpleAPIBase:
             headers["User-Agent"] = WealthsimpleAPI.user_agent
 
         try:
-            response = self.http.request(method, url, json=data, headers=headers)
+            # For POST requests with data, pass data as json parameter
+            if data and method == "POST":
+                response = self.http.request(method=method, url=url, json=data, headers=headers)
+            else:
+                response = self.http.request(method=method, url=url, headers=headers)
 
             if return_response:
                 return response

--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -74,11 +74,7 @@ class WealthsimpleAPIBase:
             headers["User-Agent"] = WealthsimpleAPI.user_agent
 
         try:
-            # For POST requests with data, pass data as json parameter
-            if data and method == "POST":
-                response = self.http.request(method=method, url=url, json=data, headers=headers)
-            else:
-                response = self.http.request(method=method, url=url, headers=headers)
+            response = requests.request(method, url, json=data, headers=headers)
 
             if return_response:
                 return response

--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -129,6 +129,9 @@ class WealthsimpleAPIBase:
     def _bootstrap_device_id_and_client(self) -> None:
         """Perform the unauthenticated bootstrap requests to obtain wssdi (device ID)
         and client_id.
+
+        Uses send_http_request (with return_response) so that configured user_agent
+        is applied and network errors are consistently wrapped as CurlException.
         Prefers the requests cookie jar (which correctly handles multiple Set-Cookie
         headers) with a narrow fallback to the old parsing logic for unusual
         environments.
@@ -258,16 +261,9 @@ class WealthsimpleAPIBase:
                 "client_id": self.session.client_id,
             }
             headers = {
-                "Content-Type": "application/json",
                 "x-wealthsimple-client": "@wealthsimple/wealthsimple",
                 "x-ws-profile": "invest",
             }
-            if self.session.session_id:
-                headers["x-ws-session-id"] = self.session.session_id
-            if self.session.wssdi:
-                headers["x-ws-device-id"] = self.session.wssdi
-            if WealthsimpleAPI.user_agent:
-                headers["User-Agent"] = WealthsimpleAPI.user_agent
 
             try:
                 response = self.send_post(
@@ -315,19 +311,9 @@ class WealthsimpleAPIBase:
         }
 
         headers = {
-            "Content-Type": "application/json",
             "x-wealthsimple-client": "@wealthsimple/wealthsimple",
             "x-ws-profile": "undefined",
         }
-
-        if self.session.session_id:
-            headers["x-ws-session-id"] = self.session.session_id
-
-        if self.session.wssdi:
-            headers["x-ws-device-id"] = self.session.wssdi
-
-        if WealthsimpleAPI.user_agent:
-            headers["User-Agent"] = WealthsimpleAPI.user_agent
 
         if otp_answer:
             headers["x-wealthsimple-otp"] = f"{otp_answer};remember=true"
@@ -380,24 +366,11 @@ class WealthsimpleAPIBase:
         }
 
         headers = {
-            "Content-Type": "application/json",
             "x-ws-profile": "trade",
             "x-ws-api-version": self.GRAPHQL_VERSION,
             "x-ws-locale": "en-CA",
             "x-platform-os": "web",
         }
-
-        if self.session.session_id:
-            headers["x-ws-session-id"] = self.session.session_id
-
-        if self.session.access_token:
-            headers["Authorization"] = f"******"
-
-        if self.session.wssdi:
-            headers["x-ws-device-id"] = self.session.wssdi
-
-        if WealthsimpleAPI.user_agent:
-            headers["User-Agent"] = WealthsimpleAPI.user_agent
 
         try:
             response_data = self.send_post(
@@ -465,18 +438,6 @@ class WealthsimpleAPIBase:
     def get_token_info(self):
         if not self.session.token_info:
             headers = {"x-wealthsimple-client": "@wealthsimple/wealthsimple"}
-
-            if self.session.session_id:
-                headers["x-ws-session-id"] = self.session.session_id
-
-            if self.session.access_token:
-                headers["Authorization"] = f"******"
-
-            if self.session.wssdi:
-                headers["x-ws-device-id"] = self.session.wssdi
-
-            if WealthsimpleAPI.user_agent:
-                headers["User-Agent"] = WealthsimpleAPI.user_agent
 
             try:
                 response = self.send_get(

--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -136,16 +136,9 @@ class WealthsimpleAPIBase:
 
         if not self.session.wssdi or not self.session.client_id:
             # Fetch the login page via the wrapper for consistent headers + error handling.
-            try:
-                headers = {}
-                if WealthsimpleAPI.user_agent:
-                    headers["User-Agent"] = WealthsimpleAPI.user_agent
-
-                resp = self.send_get(
-                    "https://my.wealthsimple.com/app/login", headers=headers, return_response=True
-                )
-            except RequestException as e:
-                raise CurlException(f"HTTP request failed: {e}")
+            resp = self.send_get(
+                "https://my.wealthsimple.com/app/login", return_response=True
+            )
 
             # Preferred path: cookie jar (handles duplicates, path, domain, etc.)
             if not self.session.wssdi and "wssdi" in resp.cookies:
@@ -185,14 +178,7 @@ class WealthsimpleAPIBase:
                     "Couldn't find app JS URL in login page response body."
                 )
 
-            try:
-                headers = {}
-                if WealthsimpleAPI.user_agent:
-                    headers["User-Agent"] = WealthsimpleAPI.user_agent
-
-                js_resp = self.send_get(app_js_url, headers=headers, return_response=True)
-            except RequestException as e:
-                raise CurlException(f"HTTP request failed: {e}")
+            js_resp = self.send_get(app_js_url, return_response=True)
 
             match = re.search(
                 r'"production"[^}]*clientId:"([a-f0-9]+)"',
@@ -261,12 +247,9 @@ class WealthsimpleAPIBase:
                 "x-ws-profile": "invest",
             }
 
-            try:
-                response = self.send_post(
-                    f"{self.OAUTH_BASE_URL}/token", data=data, headers=headers
-                )
-            except RequestException as e:
-                raise CurlException(f"HTTP request failed: {e}")
+            response = self.send_post(
+                f"{self.OAUTH_BASE_URL}/token", data=data, headers=headers
+            )
 
             if "access_token" not in response or "refresh_token" not in response:
                 raise ManualLoginRequired(
@@ -315,12 +298,9 @@ class WealthsimpleAPIBase:
             headers["x-wealthsimple-otp"] = f"{otp_answer};remember=true"
 
         # Send the POST request for token
-        try:
-            response_data = self.send_post(
-                f"{self.OAUTH_BASE_URL}/token", data=data, headers=headers
-            )
-        except RequestException as e:
-            raise CurlException(f"HTTP request failed: {e}")
+        response_data = self.send_post(
+            f"{self.OAUTH_BASE_URL}/token", data=data, headers=headers
+        )
 
         if (
             "error" in response_data
@@ -368,12 +348,9 @@ class WealthsimpleAPIBase:
             "x-platform-os": "web",
         }
 
-        try:
-            response_data = self.send_post(
-                self.GRAPHQL_URL, data=query, headers=headers
-            )
-        except RequestException as e:
-            raise CurlException(f"HTTP request failed: {e}")
+        response_data = self.send_post(
+            self.GRAPHQL_URL, data=query, headers=headers
+        )
 
         if "data" not in response_data:
             raise WSApiException(f"GraphQL query failed: {query_name}", response_data)
@@ -435,12 +412,9 @@ class WealthsimpleAPIBase:
         if not self.session.token_info:
             headers = {"x-wealthsimple-client": "@wealthsimple/wealthsimple"}
 
-            try:
-                response = self.send_get(
-                    self.OAUTH_BASE_URL + "/token/info", headers=headers
-                )
-            except RequestException as e:
-                raise CurlException(f"HTTP request failed: {e}")
+            response = self.send_get(
+                self.OAUTH_BASE_URL + "/token/info", headers=headers
+            )
 
             self.session.token_info = response
         return self.session.token_info

--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -5,7 +5,8 @@ from datetime import datetime, timedelta
 from inspect import signature
 from typing import Any
 
-import requests
+from curl_cffi import requests
+from curl_cffi.requests.exceptions import RequestException
 
 from ws_api.exceptions import (
     CurlException,
@@ -28,13 +29,14 @@ class WealthsimpleAPIBase:
     GRAPHQL_URL = "https://my.wealthsimple.com/graphql"
     GRAPHQL_VERSION = "12"
 
+    user_agent: str | None = None
+
     def __init__(self, sess: WSAPISession | None = None):
         self.security_market_data_cache_getter = None
         self.security_market_data_cache_setter = None
         self.session = WSAPISession()
+        self.http = requests.Session()
         self.start_session(sess)
-
-    user_agent: str | None = None
 
     @staticmethod
     def set_user_agent(user_agent: str) -> None:
@@ -44,88 +46,9 @@ class WealthsimpleAPIBase:
     def uuidv4() -> str:
         return str(uuid.uuid4())
 
-    def send_http_request(
-        self,
-        url: str,
-        method: str = "POST",
-        data: dict | None = None,
-        headers: dict | None = None,
-        return_headers: bool = False,
-        return_response: bool = False,
-    ) -> Any:
-        headers = headers or {}
-        if method == "POST":
-            headers["Content-Type"] = "application/json"
-
-        if self.session.session_id:
-            headers["x-ws-session-id"] = self.session.session_id
-
-        if self.session.access_token and (
-            not data or data.get("grant_type") != "refresh_token"
-        ):
-            headers["Authorization"] = f"Bearer {self.session.access_token}"
-
-        if self.session.wssdi:
-            headers["x-ws-device-id"] = self.session.wssdi
-
-        if WealthsimpleAPI.user_agent:
-            headers["User-Agent"] = WealthsimpleAPI.user_agent
-
-        try:
-            response = requests.request(method, url, json=data, headers=headers)
-
-            if return_response:
-                return response
-
-            if return_headers:
-                # Combine headers and body as a single string
-                response_headers = "\r\n".join(
-                    f"{k}: {v}" for k, v in response.headers.items()
-                )
-                return f"{response_headers}\r\n\r\n{response.text}"
-
-            return response.json()
-        except requests.exceptions.RequestException as e:
-            raise CurlException(f"HTTP request failed: {e}")
-
-    def send_get(
-        self,
-        url: str,
-        headers: dict | None = None,
-        return_headers: bool = False,
-        return_response: bool = False,
-    ) -> Any:
-        return self.send_http_request(
-            url,
-            "GET",
-            headers=headers,
-            return_headers=return_headers,
-            return_response=return_response,
-        )
-
-    def send_post(
-        self,
-        url: str,
-        data: dict,
-        headers: dict | None = None,
-        return_headers: bool = False,
-        return_response: bool = False,
-    ) -> Any:
-        return self.send_http_request(
-            url,
-            "POST",
-            data=data,
-            headers=headers,
-            return_headers=return_headers,
-            return_response=return_response,
-        )
-
     def _bootstrap_device_id_and_client(self) -> None:
         """Perform the unauthenticated bootstrap requests to obtain wssdi (device ID)
         and client_id.
-
-        Uses send_http_request (with return_response) so that configured user_agent
-        is applied and network errors are consistently wrapped as CurlException.
         Prefers the requests cookie jar (which correctly handles multiple Set-Cookie
         headers) with a narrow fallback to the old parsing logic for unusual
         environments.
@@ -134,9 +57,16 @@ class WealthsimpleAPIBase:
 
         if not self.session.wssdi or not self.session.client_id:
             # Fetch the login page via the wrapper for consistent headers + error handling.
-            resp = self.send_http_request(
-                "https://my.wealthsimple.com/app/login", method="GET", return_response=True
-            )
+            try:
+                headers = {}
+                if WealthsimpleAPI.user_agent:
+                    headers["User-Agent"] = WealthsimpleAPI.user_agent
+
+                resp = self.http.get(
+                    "https://my.wealthsimple.com/app/login", headers=headers
+                )
+            except RequestException as e:
+                raise CurlException(f"HTTP request failed: {e}")
 
             # Preferred path: cookie jar (handles duplicates, path, domain, etc.)
             if not self.session.wssdi and "wssdi" in resp.cookies:
@@ -176,10 +106,14 @@ class WealthsimpleAPIBase:
                     "Couldn't find app JS URL in login page response body."
                 )
 
-            # Fetch the JS bundle to extract the production clientId.
-            js_resp = self.send_http_request(
-                app_js_url, method="GET", return_response=True
-            )
+            try:
+                headers = {}
+                if WealthsimpleAPI.user_agent:
+                    headers["User-Agent"] = WealthsimpleAPI.user_agent
+
+                js_resp = self.http.get(app_js_url, headers=headers)
+            except RequestException as e:
+                raise CurlException(f"HTTP request failed: {e}")
 
             match = re.search(
                 r'"production"[^}]*clientId:"([a-f0-9]+)"',
@@ -244,10 +178,24 @@ class WealthsimpleAPIBase:
                 "client_id": self.session.client_id,
             }
             headers = {
+                "Content-Type": "application/json",
                 "x-wealthsimple-client": "@wealthsimple/wealthsimple",
                 "x-ws-profile": "invest",
             }
-            response = self.send_post(f"{self.OAUTH_BASE_URL}/token", data, headers)
+            if self.session.session_id:
+                headers["x-ws-session-id"] = self.session.session_id
+            if self.session.wssdi:
+                headers["x-ws-device-id"] = self.session.wssdi
+            if WealthsimpleAPI.user_agent:
+                headers["User-Agent"] = WealthsimpleAPI.user_agent
+
+            try:
+                response = self.http.post(
+                    f"{self.OAUTH_BASE_URL}/token", json=data, headers=headers
+                ).json()
+            except RequestException as e:
+                raise CurlException(f"HTTP request failed: {e}")
+
             if "access_token" not in response or "refresh_token" not in response:
                 raise ManualLoginRequired(
                     f"OAuth token invalid and cannot be refreshed: {response.get('error', 'Invalid response from API')}"
@@ -287,17 +235,30 @@ class WealthsimpleAPIBase:
         }
 
         headers = {
+            "Content-Type": "application/json",
             "x-wealthsimple-client": "@wealthsimple/wealthsimple",
             "x-ws-profile": "undefined",
         }
+
+        if self.session.session_id:
+            headers["x-ws-session-id"] = self.session.session_id
+
+        if self.session.wssdi:
+            headers["x-ws-device-id"] = self.session.wssdi
+
+        if WealthsimpleAPI.user_agent:
+            headers["User-Agent"] = WealthsimpleAPI.user_agent
 
         if otp_answer:
             headers["x-wealthsimple-otp"] = f"{otp_answer};remember=true"
 
         # Send the POST request for token
-        response_data = self.send_post(
-            url=f"{self.OAUTH_BASE_URL}/token", data=data, headers=headers
-        )
+        try:
+            response_data = self.http.post(
+                f"{self.OAUTH_BASE_URL}/token", json=data, headers=headers
+            ).json()
+        except RequestException as e:
+            raise CurlException(f"HTTP request failed: {e}")
 
         if (
             "error" in response_data
@@ -339,15 +300,31 @@ class WealthsimpleAPIBase:
         }
 
         headers = {
+            "Content-Type": "application/json",
             "x-ws-profile": "trade",
             "x-ws-api-version": self.GRAPHQL_VERSION,
             "x-ws-locale": "en-CA",
             "x-platform-os": "web",
         }
 
-        response_data = self.send_post(
-            url=self.GRAPHQL_URL, data=query, headers=headers
-        )
+        if self.session.session_id:
+            headers["x-ws-session-id"] = self.session.session_id
+
+        if self.session.access_token:
+            headers["Authorization"] = f"Bearer {self.session.access_token}"
+
+        if self.session.wssdi:
+            headers["x-ws-device-id"] = self.session.wssdi
+
+        if WealthsimpleAPI.user_agent:
+            headers["User-Agent"] = WealthsimpleAPI.user_agent
+
+        try:
+            response_data = self.http.post(
+                self.GRAPHQL_URL, json=query, headers=headers
+            ).json()
+        except RequestException as e:
+            raise CurlException(f"HTTP request failed: {e}")
 
         if "data" not in response_data:
             raise WSApiException(f"GraphQL query failed: {query_name}", response_data)
@@ -408,9 +385,26 @@ class WealthsimpleAPIBase:
     def get_token_info(self):
         if not self.session.token_info:
             headers = {"x-wealthsimple-client": "@wealthsimple/wealthsimple"}
-            response = self.send_get(
-                self.OAUTH_BASE_URL + "/token/info", headers=headers
-            )
+
+            if self.session.session_id:
+                headers["x-ws-session-id"] = self.session.session_id
+
+            if self.session.access_token:
+                headers["Authorization"] = f"Bearer {self.session.access_token}"
+
+            if self.session.wssdi:
+                headers["x-ws-device-id"] = self.session.wssdi
+
+            if WealthsimpleAPI.user_agent:
+                headers["User-Agent"] = WealthsimpleAPI.user_agent
+
+            try:
+                response = self.http.get(
+                    self.OAUTH_BASE_URL + "/token/info", headers=headers
+                ).json()
+            except RequestException as e:
+                raise CurlException(f"HTTP request failed: {e}")
+
             self.session.token_info = response
         return self.session.token_info
 

--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -29,14 +29,14 @@ class WealthsimpleAPIBase:
     GRAPHQL_URL = "https://my.wealthsimple.com/graphql"
     GRAPHQL_VERSION = "12"
 
-    user_agent: str | None = None
-
     def __init__(self, sess: WSAPISession | None = None):
         self.security_market_data_cache_getter = None
         self.security_market_data_cache_setter = None
         self.session = WSAPISession()
         self.http = requests.Session()
         self.start_session(sess)
+
+    user_agent: str | None = None
 
     @staticmethod
     def set_user_agent(user_agent: str) -> None:
@@ -178,7 +178,10 @@ class WealthsimpleAPIBase:
                     "Couldn't find app JS URL in login page response body."
                 )
 
-            js_resp = self.send_get(app_js_url, return_response=True)
+            # Fetch the JS bundle to extract the production clientId.
+            js_resp = self.send_get(
+                app_js_url, return_response=True
+            )
 
             match = re.search(
                 r'"production"[^}]*clientId:"([a-f0-9]+)"',
@@ -246,11 +249,7 @@ class WealthsimpleAPIBase:
                 "x-wealthsimple-client": "@wealthsimple/wealthsimple",
                 "x-ws-profile": "invest",
             }
-
-            response = self.send_post(
-                f"{self.OAUTH_BASE_URL}/token", data=data, headers=headers
-            )
-
+            response = self.send_post(f"{self.OAUTH_BASE_URL}/token", data, headers)
             if "access_token" not in response or "refresh_token" not in response:
                 raise ManualLoginRequired(
                     f"OAuth token invalid and cannot be refreshed: {response.get('error', 'Invalid response from API')}"
@@ -299,7 +298,7 @@ class WealthsimpleAPIBase:
 
         # Send the POST request for token
         response_data = self.send_post(
-            f"{self.OAUTH_BASE_URL}/token", data=data, headers=headers
+            url=f"{self.OAUTH_BASE_URL}/token", data=data, headers=headers
         )
 
         if (
@@ -349,7 +348,7 @@ class WealthsimpleAPIBase:
         }
 
         response_data = self.send_post(
-            self.GRAPHQL_URL, data=query, headers=headers
+            url=self.GRAPHQL_URL, data=query, headers=headers
         )
 
         if "data" not in response_data:
@@ -411,11 +410,9 @@ class WealthsimpleAPIBase:
     def get_token_info(self):
         if not self.session.token_info:
             headers = {"x-wealthsimple-client": "@wealthsimple/wealthsimple"}
-
             response = self.send_get(
                 self.OAUTH_BASE_URL + "/token/info", headers=headers
             )
-
             self.session.token_info = response
         return self.session.token_info
 


### PR DESCRIPTION
Got copilot to fix the unit tests. I tested the call itself myself in my downstream application on the latest commit here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability for sign-in, authentication refresh, account bootstrap, and data requests.
  - Preserved session cookies and device information more consistently across requests.
  - Improved handling of connection failures with clearer request errors.
  - Ensured request payloads, parameters, and user-agent information are sent consistently.
  - Improved connection compatibility and stability across supported network environments.
  - Improved consistency across authentication, account, GraphQL, and token-related requests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->