### PR TITLE
Use extensions.code instead of message to detect expired token.

### DIFF
--- a/ws_api/wealthsimple_api.py
+++ b/ws_api/wealthsimple_api.py
@@ -228,11 +228,18 @@ class WealthsimpleAPIBase:
             except WSApiException as e:
                 errors = e.response.get("errors") if e.response is not None else None
                 first_error = errors[0] if isinstance(errors, list) and errors else None
+                code = (
+                    (first_error.get("extensions") or {}).get("code")
+                    if isinstance(first_error, dict)
+                    else None
+                )
                 is_not_authorized = e.response is not None and (
-                    e.response.get("message") == "Not Authorized."
+                    code == "UNAUTHENTICATED"
+                    or (e.response.get("message") or "").rstrip(".") == "Not Authorized"
                     or (
                         isinstance(first_error, dict)
-                        and first_error.get("message") == "Not Authorized."
+                        and (first_error.get("message") or "").rstrip(".")
+                        == "Not Authorized"
                     )
                 )
                 if not is_not_authorized:


### PR DESCRIPTION
I some times get 

```
{'errors': [{'message': 'Not Authorized', 'extensions': {'code': 'UNAUTHENTICATED'}}]}
```

instead of 

```
{'errors': [{'message': 'Not Authorized.', 'extensions': {'code': 'UNAUTHENTICATED'}}]}
```

for expired token which then raised the following exception:

ws_api.exceptions.WSApiException: GraphQL query failed: FetchSecuritySearchResult; Response: {'errors': [{'message': 'Not Authorized', 'extensions': {'code': 'UNAUTHENTICATED'}}]}
Failed to run task: exit status 1

Proposing using extensions.code to detect expired tokens instead of the message which sometimes is 'Not Authorized.', and sometimes is 'Not Authorized'.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication failure detection for GraphQL responses.
  * Correctly handles unauthorized messages with or without trailing periods.
  * Ensures expired or invalid sessions are identified more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->